### PR TITLE
Add `.editorconfig` for consisted coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst,ini}]
+indent_style = space
+indent_size = 4
+
+[*.py]
+max_line_length = 119
+
+[*.{html,css,scss,json,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[nginx.conf]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
> ### What is EditorConfig?
> 
> EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.

For example, by having this file in the root, we can instruct the IDE to always use `space` for indentation in Python files and use 4 of them for each indentation.

Notes: unfortunately, this [is not supported by Spyder yet](https://github.com/spyder-ide/spyder/issues/2336) but you can use use it in VSCode, PyCharm, Sublime Text or many others.