### PR TITLE
Add flake8 for linting with sensible defaults

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,27 @@
+[flake8]
+show-source = True
+statistics = False
+doctests = True
+enable-extensions = G
+max-line-length = 119
+select = C,E,F,W,B,B950
+extend-ignore = E203, W503
+accept-encodings = utf-8
+radon-max-cc = 10
+radon-show-closures = True
+radon-no-assert = True
+exclude = .tox,.git,__pycache__,*/migrations/*,*/static/CACHE/*,.assets,media,docs,node_modules,.venv,.eggs,*.egg,venv
+
+# Disable some pydocstyle checks:
+ignore = D100, D104, D106, D401, X100, W504, RST303, RST304
+
+# Docs: https://github.com/snoack/flake8-per-file-ignores
+# You can completely or partially disable our custom checks,
+# to do so you have to ignore `WPS` letters for all python files:
+per-file-ignores =
+  # Allow `__init__.py` with logic for configuration:
+  wiki/settings.py: WPS226, WPS407, WPS412, WPS432
+
+[pycodestyle]
+max-line-length = 119
+exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Django==3.2.5
 requests==2.26.0
+
+# === dev
+flake8==3.9.2


### PR DESCRIPTION
This is another tool to maintain a consistent coding style and standard.

> ### Lint
> 
> Lint, or a linter, is a static code analysis tool used to flag programming errors, bugs, stylistic errors and suspicious constructs.[4] The term originates from a Unix utility that examined C language source code.

Source: _https://en.wikipedia.org/wiki/Lint_(software)_

Flake8 is useful to catch a multitude of problems with Python code, from pep8 violations to documentation problems, etc.

Here is how you can use it in this project after installing flake8:

```console
> flake8
```

And the output is something like:

```zsh
./graph/sparql.py:15:1: W293 blank line contains whitespace
    
^
./graph/sparql.py:16:52: E711 comparison to None should be 'if cond is not None:'
    _Q = ['wd:' + i[0] for i in Q.values() if i[0] != None]
                                                   ^
./graph/sparql.py:26:1: W293 blank line contains whitespace
    
^
./graph/sparql.py:27:21: E225 missing whitespace around operator
    query = _query %_Q   
                    ^
```

This will not automatically fix the problems, but helps you find them. For fixing these problems automatically, we can use an auto-formatter like [black](https://black.readthedocs.io/en/stable/)!

Notes: A settings file named `.flake8` has been added to configure the library's behavior. For example, `.git`, `.venv` and `venv` folders are excluded from the checks or maximum line length is set to `119`.